### PR TITLE
remove header template parameter

### DIFF
--- a/modules/core/src/main/java/org/eclipse/imagen/AreaOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/AreaOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/AttributedImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/AttributedImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/AttributedImageCollection.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/AttributedImageCollection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/BorderExtender.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/BorderExtender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/BorderExtenderConstant.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/BorderExtenderConstant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/BorderExtenderCopy.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/BorderExtenderCopy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/BorderExtenderReflect.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/BorderExtenderReflect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/BorderExtenderWrap.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/BorderExtenderWrap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/BorderExtenderZero.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/BorderExtenderZero.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/CRIFImpl.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/CRIFImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/CachedTile.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/CachedTile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/CanvasJAI.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/CanvasJAI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/CollectionChangeEvent.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/CollectionChangeEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/CollectionImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/CollectionImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/CollectionImageFactory.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/CollectionImageFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/CollectionOp.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/CollectionOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/ColorCube.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/ColorCube.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/ColorModelFactory.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/ColorModelFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/ColorSpaceJAI.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/ColorSpaceJAI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/ColormapOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/ColormapOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/ComponentSampleModelJAI.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/ComponentSampleModelJAI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/CoordinateImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/CoordinateImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/DataBufferDouble.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/DataBufferDouble.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/DataBufferFloat.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/DataBufferFloat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/DeferredData.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/DeferredData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/DeferredProperty.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/DeferredProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/DescriptorCache.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/DescriptorCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/EnumeratedParameter.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/EnumeratedParameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/FactoryCache.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/FactoryCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/FloatDoubleColorModel.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/FloatDoubleColorModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/GeometricOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/GeometricOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/GraphicsJAI.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/GraphicsJAI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/Histogram.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/Histogram.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/IHSColorSpace.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/IHSColorSpace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/ImageFunction.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/ImageFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/ImageJAI.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/ImageJAI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/ImageLayout.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/ImageLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/ImageMIPMap.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/ImageMIPMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/ImagePyramid.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/ImagePyramid.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/ImageSequence.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/ImageSequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/ImageStack.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/ImageStack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/IntegerSequence.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/IntegerSequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/Interpolation.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/Interpolation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/InterpolationBicubic.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/InterpolationBicubic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/InterpolationBicubic2.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/InterpolationBicubic2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/InterpolationBilinear.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/InterpolationBilinear.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/InterpolationNearest.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/InterpolationNearest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/InterpolationTable.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/InterpolationTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/JAI.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/JAI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/JaiI18N.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/JaiI18N.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/KernelJAI.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/KernelJAI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/LookupTableJAI.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/LookupTableJAI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/MultiResolutionRenderableImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/MultiResolutionRenderableImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/NullCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/NullCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/NullOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/NullOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/OpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/OpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/OperationDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/OperationDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/OperationDescriptorImpl.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/OperationDescriptorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/OperationGraph.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/OperationGraph.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/OperationNode.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/OperationNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/OperationNodeSupport.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/OperationNodeSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/OperationRegistry.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/OperationRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/OperationRegistrySpi.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/OperationRegistrySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/PackedImageData.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/PackedImageData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/ParameterBlockJAI.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/ParameterBlockJAI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/ParameterList.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/ParameterList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/ParameterListDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/ParameterListDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/ParameterListDescriptorImpl.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/ParameterListDescriptorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/ParameterListImpl.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/ParameterListImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/PartialOrderNode.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/PartialOrderNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/PerspectiveTransform.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/PerspectiveTransform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/PixelAccessor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/PixelAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/PlanarImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/PlanarImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/PointOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/PointOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/ProductOperationGraph.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/ProductOperationGraph.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/PropertyChangeEmitter.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/PropertyChangeEmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/PropertyChangeEventJAI.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/PropertyChangeEventJAI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/PropertyChangeSupportJAI.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/PropertyChangeSupportJAI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/PropertyEnvironment.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/PropertyEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/PropertyGenerator.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/PropertyGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/PropertyGeneratorFromSource.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/PropertyGeneratorFromSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/PropertySource.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/PropertySource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/PropertySourceChangeEvent.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/PropertySourceChangeEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/PropertySourceImpl.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/PropertySourceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/ROI.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/ROI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/ROIShape.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/ROIShape.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/RasterAccessor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/RasterAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/RasterFactory.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/RasterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/RasterFormatTag.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/RasterFormatTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/RecyclingTileFactory.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/RecyclingTileFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/RegistryElementDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/RegistryElementDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/RegistryFileParser.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/RegistryFileParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/RegistryMode.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/RegistryMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/RemoteImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/RemoteImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/RenderableCollectionImageFactory.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/RenderableCollectionImageFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/RenderableGraphics.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/RenderableGraphics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/RenderableImageAdapter.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/RenderableImageAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/RenderableOp.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/RenderableOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/RenderedImageAdapter.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/RenderedImageAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/RenderedImageList.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/RenderedImageList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/RenderedOp.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/RenderedOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/RenderingChangeEvent.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/RenderingChangeEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/ScaleOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/ScaleOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/SequentialImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/SequentialImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/SnapshotImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/SnapshotImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/SourcelessOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/SourcelessOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/StatisticsOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/StatisticsOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/ThreadSafeOperationRegistry.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/ThreadSafeOperationRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/TileCache.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/TileCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/TileComputationListener.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/TileComputationListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/TileFactory.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/TileFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/TileRecycler.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/TileRecycler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/TileRequest.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/TileRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/TileScheduler.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/TileScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/TiledImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/TiledImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/TiledImageGraphics.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/TiledImageGraphics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/UnpackedImageData.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/UnpackedImageData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/UntiledOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/UntiledOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/Warp.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/Warp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/WarpAffine.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/WarpAffine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/WarpCubic.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/WarpCubic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/WarpGeneralPolynomial.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/WarpGeneralPolynomial.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/WarpGrid.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/WarpGrid.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/WarpOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/WarpOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/WarpPerspective.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/WarpPerspective.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/WarpPolynomial.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/WarpPolynomial.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/WarpQuadratic.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/WarpQuadratic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/WritablePropertySource.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/WritablePropertySource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/WritablePropertySourceImpl.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/WritablePropertySourceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/WritableRenderedImageAdapter.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/WritableRenderedImageAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/iterator/JaiI18N.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/iterator/JaiI18N.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/iterator/RandomIter.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/iterator/RandomIter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/iterator/RandomIterFactory.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/iterator/RandomIterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/iterator/RectIter.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/iterator/RectIter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/iterator/RectIterFactory.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/iterator/RectIterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/iterator/RookIter.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/iterator/RookIter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/iterator/RookIterFactory.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/iterator/RookIterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/iterator/WritableRandomIter.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/iterator/WritableRandomIter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/iterator/WritableRectIter.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/iterator/WritableRectIter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/iterator/WritableRookIter.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/iterator/WritableRookIter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codec/BMPEncodeParam.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codec/BMPEncodeParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codec/ByteArraySeekableStream.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codec/ByteArraySeekableStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codec/FPXDecodeParam.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codec/FPXDecodeParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codec/FileCacheSeekableStream.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codec/FileCacheSeekableStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codec/FileSeekableStream.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codec/FileSeekableStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codec/ForwardSeekableStream.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codec/ForwardSeekableStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codec/ImageCodec.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codec/ImageCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codec/ImageDecodeParam.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codec/ImageDecodeParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codec/ImageDecoder.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codec/ImageDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codec/ImageDecoderImpl.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codec/ImageDecoderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codec/ImageEncodeParam.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codec/ImageEncodeParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codec/ImageEncoder.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codec/ImageEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codec/ImageEncoderImpl.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codec/ImageEncoderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codec/JPEGDecodeParam.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codec/JPEGDecodeParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codec/JPEGEncodeParam.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codec/JPEGEncodeParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codec/JaiI18N.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codec/JaiI18N.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codec/MemoryCacheSeekableStream.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codec/MemoryCacheSeekableStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codec/PNGDecodeParam.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codec/PNGDecodeParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codec/PNGEncodeParam.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codec/PNGEncodeParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codec/PNGSuggestedPaletteEntry.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codec/PNGSuggestedPaletteEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codec/PNMEncodeParam.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codec/PNMEncodeParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codec/SeekableOutputStream.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codec/SeekableOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codec/SeekableStream.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codec/SeekableStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codec/SegmentedSeekableStream.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codec/SegmentedSeekableStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codec/StreamSegment.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codec/StreamSegment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codec/StreamSegmentMapper.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codec/StreamSegmentMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codec/TIFFDecodeParam.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codec/TIFFDecodeParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codec/TIFFDirectory.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codec/TIFFDirectory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codec/TIFFEncodeParam.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codec/TIFFEncodeParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codec/TIFFField.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codec/TIFFField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/BMPCodec.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/BMPCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/BMPImageDecoder.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/BMPImageDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/BMPImageEncoder.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/BMPImageEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/CodecUtils.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/CodecUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/FPXCodec.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/FPXCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/FPXImageDecoder.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/FPXImageDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/GIFCodec.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/GIFCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/GIFImageDecoder.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/GIFImageDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/ImagingListenerProxy.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/ImagingListenerProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/JPEGCodec.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/JPEGCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/JPEGImageDecoder.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/JPEGImageDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/JPEGImageEncoder.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/JPEGImageEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/JaiI18N.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/JaiI18N.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/PNGCodec.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/PNGCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/PNGImageDecoder.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/PNGImageDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/PNGImageEncoder.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/PNGImageEncoder.java
@@ -1,7 +1,7 @@
 /*
  * $RCSfile: PNGImageEncoder.java,v $
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/PNMCodec.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/PNMCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/PNMImageDecoder.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/PNMImageDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/PNMImageEncoder.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/PNMImageEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/SimpleRenderedImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/SimpleRenderedImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/SingleTileRenderedImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/SingleTileRenderedImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/TIFFCodec.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/TIFFCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/TIFFFaxDecoder.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/TIFFFaxDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/TIFFFaxEncoder.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/TIFFFaxEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/TIFFImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/TIFFImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/TIFFImageDecoder.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/TIFFImageDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/TIFFImageEncoder.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/TIFFImageEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/TIFFLZWDecoder.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/TIFFLZWDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/WBMPCodec.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/WBMPCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/fpx/FPXImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/fpx/FPXImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/fpx/FPXUtils.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/fpx/FPXUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/fpx/JaiI18N.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/fpx/JaiI18N.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/fpx/PropertySet.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/fpx/PropertySet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/fpx/StructuredStorage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/fpx/StructuredStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/util/ComponentSampleModelJAI.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/util/ComponentSampleModelJAI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/util/DataBufferDouble.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/util/DataBufferDouble.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/util/DataBufferFloat.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/util/DataBufferFloat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/util/DataBufferUtils.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/util/DataBufferUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/util/FloatDoubleColorModel.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/util/FloatDoubleColorModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/util/ImagingException.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/util/ImagingException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/util/JaiI18N.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/util/JaiI18N.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/util/PropertyUtil.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/util/PropertyUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/util/RasterFactory.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/codecimpl/util/RasterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/iterator/JaiI18N.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/iterator/JaiI18N.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/iterator/RandomIterCSM.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/iterator/RandomIterCSM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/iterator/RandomIterCSMByte.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/iterator/RandomIterCSMByte.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/iterator/RandomIterCSMDouble.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/iterator/RandomIterCSMDouble.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/iterator/RandomIterCSMFloat.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/iterator/RandomIterCSMFloat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/iterator/RandomIterCSMInt.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/iterator/RandomIterCSMInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/iterator/RandomIterCSMShort.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/iterator/RandomIterCSMShort.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/iterator/RandomIterCSMUShort.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/iterator/RandomIterCSMUShort.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/iterator/RandomIterFallback.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/iterator/RandomIterFallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/iterator/RectIterCSM.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/iterator/RectIterCSM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/iterator/RectIterCSMByte.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/iterator/RectIterCSMByte.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/iterator/RectIterCSMFloat.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/iterator/RectIterCSMFloat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/iterator/RectIterFallback.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/iterator/RectIterFallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/iterator/RookIterFallback.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/iterator/RookIterFallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/iterator/WrapperRI.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/iterator/WrapperRI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/iterator/WrapperWRI.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/iterator/WrapperWRI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/iterator/WritableRandomIterCSMByte.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/iterator/WritableRandomIterCSMByte.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/iterator/WritableRandomIterCSMDouble.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/iterator/WritableRandomIterCSMDouble.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/iterator/WritableRandomIterCSMFloat.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/iterator/WritableRandomIterCSMFloat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/iterator/WritableRandomIterCSMInt.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/iterator/WritableRandomIterCSMInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/iterator/WritableRandomIterCSMShort.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/iterator/WritableRandomIterCSMShort.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/iterator/WritableRandomIterCSMUShort.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/iterator/WritableRandomIterCSMUShort.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/iterator/WritableRandomIterFallback.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/iterator/WritableRandomIterFallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/iterator/WritableRectIterCSMByte.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/iterator/WritableRectIterCSMByte.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/iterator/WritableRectIterCSMFloat.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/iterator/WritableRectIterCSMFloat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/iterator/WritableRectIterFallback.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/iterator/WritableRectIterFallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/iterator/WritableRookIterFallback.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/iterator/WritableRookIterFallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AWTImageOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AWTImageOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AWTImageRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AWTImageRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AbsoluteCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AbsoluteCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AbsoluteOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AbsoluteOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AddCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AddCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AddCollectionCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AddCollectionCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AddCollectionOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AddCollectionOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AddConstCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AddConstCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AddConstOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AddConstOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AddConstToCollectionCIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AddConstToCollectionCIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AddConstToCollectionOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AddConstToCollectionOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AddOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AddOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AffineBicubic2OpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AffineBicubic2OpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AffineBicubicOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AffineBicubicOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AffineBilinearOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AffineBilinearOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AffineCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AffineCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AffineGeneralOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AffineGeneralOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AffineNearestBinaryOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AffineNearestBinaryOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AffineNearestOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AffineNearestOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AffineOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AffineOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AndCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AndCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AndConstCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AndConstCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AndConstOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AndConstOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AndOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AndOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/BMPRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/BMPRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/BandCombineCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/BandCombineCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/BandCombineOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/BandCombineOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/BandMergeCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/BandMergeCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/BandMergeOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/BandMergeOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/BandSelectCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/BandSelectCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/BandSelectOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/BandSelectOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/BinarizeCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/BinarizeCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/BinarizeOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/BinarizeOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/BorderOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/BorderOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/BorderRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/BorderRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/BoxFilterRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/BoxFilterRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ClampCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ClampCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ClampOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ClampOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/CodecRIFUtil.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/CodecRIFUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ColorConvertCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ColorConvertCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ColorConvertOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ColorConvertOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ColorQuantizerOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ColorQuantizerOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ColorQuantizerRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ColorQuantizerRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ComplexArithmeticOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ComplexArithmeticOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/CompositeCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/CompositeCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/CompositeNoDestAlphaOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/CompositeNoDestAlphaOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/CompositeOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/CompositeOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ConjugateCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ConjugateCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ConjugateOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ConjugateOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ConstantCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ConstantCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ConstantOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ConstantOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/Convolve3x3OpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/Convolve3x3OpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ConvolveOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ConvolveOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ConvolveRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ConvolveRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/CopyOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/CopyOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/CropCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/CropCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/CropOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/CropOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/DCTCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/DCTCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/DCTOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/DCTOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/DFTCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/DFTCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/DFTOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/DFTOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/DilateBinaryOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/DilateBinaryOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/DilateOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/DilateOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/DilateRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/DilateRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/DivideByConstCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/DivideByConstCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/DivideCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/DivideCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/DivideComplexCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/DivideComplexCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/DivideIntoConstCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/DivideIntoConstCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/DivideIntoConstOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/DivideIntoConstOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/DivideOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/DivideOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/EncodeRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/EncodeRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ErodeBinaryOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ErodeBinaryOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ErodeOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ErodeOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ErodeRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ErodeRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ErrorDiffusionOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ErrorDiffusionOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ErrorDiffusionRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ErrorDiffusionRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ExpCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ExpCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ExpOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ExpOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ExtremaOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ExtremaOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ExtremaRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ExtremaRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/FCT.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/FCT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/FFT.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/FFT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/FPXRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/FPXRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/FileLoadRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/FileLoadRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/FileStoreRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/FileStoreRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/FilterCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/FilterCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/FilteredSubsampleOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/FilteredSubsampleOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/FilteredSubsampleRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/FilteredSubsampleRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/FormatCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/FormatCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/GIFRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/GIFRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/GradientOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/GradientOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/GradientRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/GradientRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/HistogramOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/HistogramOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/HistogramRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/HistogramRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/IDCTCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/IDCTCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/IDFTCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/IDFTCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/IIPCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/IIPCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/IIPResolutionOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/IIPResolutionOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/IIPResolutionRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/IIPResolutionRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ImageFunctionOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ImageFunctionOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ImageFunctionRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ImageFunctionRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/InvertCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/InvertCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/InvertOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/InvertOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/JPEGRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/JPEGRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/JaiI18N.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/JaiI18N.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/LogCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/LogCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/LogOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/LogOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/LookupCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/LookupCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/LookupOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/LookupOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MagnitudeCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MagnitudeCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MagnitudePhaseOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MagnitudePhaseOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MagnitudeSquaredCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MagnitudeSquaredCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MatchCDFCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MatchCDFCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MaxCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MaxCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MaxFilterOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MaxFilterOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MaxFilterPlusOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MaxFilterPlusOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MaxFilterRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MaxFilterRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MaxFilterSeparableOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MaxFilterSeparableOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MaxFilterSquareOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MaxFilterSquareOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MaxFilterXOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MaxFilterXOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MaxOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MaxOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MeanOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MeanOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MeanRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MeanRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MedianCutOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MedianCutOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MedianFilterOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MedianFilterOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MedianFilterPlusOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MedianFilterPlusOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MedianFilterRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MedianFilterRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MedianFilterSeparableOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MedianFilterSeparableOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MedianFilterSquareOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MedianFilterSquareOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MedianFilterXOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MedianFilterXOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MinCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MinCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MinFilterOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MinFilterOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MinFilterPlusOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MinFilterPlusOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MinFilterRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MinFilterRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MinFilterSeparableOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MinFilterSeparableOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MinFilterSquareOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MinFilterSquareOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MinFilterXOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MinFilterXOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MinOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MinOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MosaicOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MosaicOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MosaicRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MosaicRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MultiplyCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MultiplyCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MultiplyComplexCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MultiplyComplexCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MultiplyConstCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MultiplyConstCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MultiplyConstOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MultiplyConstOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MultiplyOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MultiplyOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/NeuQuantOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/NeuQuantOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/NotCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/NotCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/NotOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/NotOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/OctTreeOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/OctTreeOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/OrCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/OrCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/OrConstCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/OrConstCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/OrConstOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/OrConstOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/OrOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/OrOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/OrderedDitherOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/OrderedDitherOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/OrderedDitherRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/OrderedDitherRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/OverlayCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/OverlayCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/OverlayOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/OverlayOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/PNGRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/PNGRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/PNMRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/PNMRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/PatternOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/PatternOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/PatternRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/PatternRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/PeriodicShiftCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/PeriodicShiftCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/PeriodicShiftOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/PeriodicShiftOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/PhaseCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/PhaseCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/PiecewiseCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/PiecewiseCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/PiecewiseOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/PiecewiseOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/PointMapperOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/PointMapperOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/PolarToComplexCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/PolarToComplexCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/PolarToComplexOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/PolarToComplexOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/RIFUtil.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/RIFUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/RenderableCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/RenderableCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/RescaleCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/RescaleCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/RescaleOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/RescaleOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/RotateCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/RotateCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ScaleBicubicOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ScaleBicubicOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ScaleBilinearBinaryOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ScaleBilinearBinaryOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ScaleBilinearOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ScaleBilinearOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ScaleCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ScaleCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ScaleGeneralOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ScaleGeneralOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ScaleNearestBinaryOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ScaleNearestBinaryOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ScaleNearestOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ScaleNearestOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/SeparableConvolveOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/SeparableConvolveOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ShearRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ShearRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/StreamRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/StreamRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/SubsampleAverageCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/SubsampleAverageCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/SubsampleAverageOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/SubsampleAverageOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/SubsampleBinaryToGray2x2OpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/SubsampleBinaryToGray2x2OpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/SubsampleBinaryToGray4x4OpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/SubsampleBinaryToGray4x4OpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/SubsampleBinaryToGrayCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/SubsampleBinaryToGrayCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/SubsampleBinaryToGrayOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/SubsampleBinaryToGrayOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/SubtractCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/SubtractCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/SubtractConstCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/SubtractConstCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/SubtractFromConstCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/SubtractFromConstCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/SubtractFromConstOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/SubtractFromConstOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/SubtractOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/SubtractOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/TIFFRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/TIFFRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ThresholdCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ThresholdCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ThresholdOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ThresholdOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/TranslateCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/TranslateCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/TranslateIntOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/TranslateIntOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/TransposeBinaryOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/TransposeBinaryOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/TransposeCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/TransposeCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/TransposeOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/TransposeOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/URLRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/URLRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/UnsharpMaskRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/UnsharpMaskRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/WarpBilinearOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/WarpBilinearOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/WarpGeneralOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/WarpGeneralOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/WarpNearestOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/WarpNearestOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/WarpRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/WarpRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/XorCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/XorCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/XorConstCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/XorConstCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/XorConstOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/XorConstOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/XorOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/XorOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/remote/JAIServerConfigurationSpi.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/remote/JAIServerConfigurationSpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/rmi/ColorModelProxy.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/rmi/ColorModelProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/rmi/ColorModelState.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/rmi/ColorModelState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/rmi/DataBufferProxy.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/rmi/DataBufferProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/rmi/DataBufferState.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/rmi/DataBufferState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/rmi/HashSetState.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/rmi/HashSetState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/rmi/HashtableState.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/rmi/HashtableState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/rmi/ImageServer.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/rmi/ImageServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/rmi/InterfaceProxy.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/rmi/InterfaceProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/rmi/InterfaceState.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/rmi/InterfaceState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/rmi/JAIRMICRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/rmi/JAIRMICRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/rmi/JAIRMIImageServer.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/rmi/JAIRMIImageServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/rmi/JAIRMIUtil.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/rmi/JAIRMIUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/rmi/JaiI18N.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/rmi/JaiI18N.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/rmi/RMIImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/rmi/RMIImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/rmi/RMIImageImpl.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/rmi/RMIImageImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/rmi/RMIServerProxy.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/rmi/RMIServerProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/rmi/RasterProxy.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/rmi/RasterProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/rmi/RasterState.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/rmi/RasterState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/rmi/RenderContextProxy.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/rmi/RenderContextProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/rmi/RenderContextState.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/rmi/RenderContextState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/rmi/RenderableRMIServerProxy.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/rmi/RenderableRMIServerProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/rmi/RenderedImageState.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/rmi/RenderedImageState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/rmi/RenderingHintsProxy.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/rmi/RenderingHintsProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/rmi/RenderingHintsState.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/rmi/RenderingHintsState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/rmi/RenderingKeyState.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/rmi/RenderingKeyState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/rmi/SampleModelProxy.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/rmi/SampleModelProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/rmi/SampleModelState.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/rmi/SampleModelState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/rmi/SerializableRenderableImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/rmi/SerializableRenderableImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/rmi/SerializableStateImpl.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/rmi/SerializableStateImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/rmi/SerializerImpl.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/rmi/SerializerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/rmi/ShapeState.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/rmi/ShapeState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/rmi/VectorState.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/rmi/VectorState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/test/CheckerboardOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/test/CheckerboardOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/test/OpImageTester.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/test/OpImageTester.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/test/RampOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/test/RampOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/test/RandomOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/test/RandomOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/test/RandomRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/test/RandomRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/tilecodec/GZIPTileDecoder.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/tilecodec/GZIPTileDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/tilecodec/GZIPTileDecoderFactory.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/tilecodec/GZIPTileDecoderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/tilecodec/GZIPTileEncoder.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/tilecodec/GZIPTileEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/tilecodec/GZIPTileEncoderFactory.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/tilecodec/GZIPTileEncoderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/tilecodec/JPEGTileDecoder.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/tilecodec/JPEGTileDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/tilecodec/JPEGTileDecoderFactory.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/tilecodec/JPEGTileDecoderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/tilecodec/JPEGTileEncoder.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/tilecodec/JPEGTileEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/tilecodec/JPEGTileEncoderFactory.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/tilecodec/JPEGTileEncoderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/tilecodec/JaiI18N.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/tilecodec/JaiI18N.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/tilecodec/RawTileDecoder.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/tilecodec/RawTileDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/tilecodec/RawTileDecoderFactory.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/tilecodec/RawTileDecoderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/tilecodec/RawTileEncoder.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/tilecodec/RawTileEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/tilecodec/RawTileEncoderFactory.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/tilecodec/RawTileEncoderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/tilecodec/TileCodecUtils.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/tilecodec/TileCodecUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/util/AreaOpPropertyGenerator.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/util/AreaOpPropertyGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/util/CacheDiagnostics.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/util/CacheDiagnostics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/util/CaselessStringArrayTable.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/util/CaselessStringArrayTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/util/CaselessStringKeyHashtable.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/util/CaselessStringKeyHashtable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/util/DataBufferUtils.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/util/DataBufferUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/util/DisposableNullOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/util/DisposableNullOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/util/ImageUtil.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/util/ImageUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/util/ImagingListenerImpl.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/util/ImagingListenerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/util/InterpAverage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/util/InterpAverage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/util/JDKWorkarounds.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/util/JDKWorkarounds.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/util/JaiI18N.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/util/JaiI18N.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/util/MathJAI.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/util/MathJAI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/util/PlanarImageProducer.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/util/PlanarImageProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/util/PolyWarpSolver.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/util/PolyWarpSolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/util/PropertyGeneratorImpl.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/util/PropertyGeneratorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/util/PropertyUtil.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/util/PropertyUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/util/RWLock.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/util/RWLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/util/Rational.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/util/Rational.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/util/Service.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/util/Service.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/util/ServiceConfigurationError.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/util/ServiceConfigurationError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/util/SimpleCMYKColorSpace.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/util/SimpleCMYKColorSpace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/util/SunCachedTile.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/util/SunCachedTile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/util/SunTileCache.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/util/SunTileCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/util/SunTileScheduler.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/util/SunTileScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/widget/DisplayJAI.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/widget/DisplayJAI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/AWTImageDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/AWTImageDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/AbsoluteDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/AbsoluteDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/AddCollectionDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/AddCollectionDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/AddConstDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/AddConstDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/AddConstToCollectionDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/AddConstToCollectionDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/AddDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/AddDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/AffineDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/AffineDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/AndConstDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/AndConstDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/AndDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/AndDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/BMPDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/BMPDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/BandCombineDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/BandCombineDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/BandMergeDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/BandMergeDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/BandSelectDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/BandSelectDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/BinarizeDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/BinarizeDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/BorderDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/BorderDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/BoxFilterDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/BoxFilterDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/ClampDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/ClampDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/ColorConvertDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/ColorConvertDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/ColorQuantizerDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/ColorQuantizerDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/ColorQuantizerType.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/ColorQuantizerType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/ComplexPropertyGenerator.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/ComplexPropertyGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/CompositeDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/CompositeDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/CompositeDestAlpha.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/CompositeDestAlpha.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/ConjugateDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/ConjugateDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/ConstantDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/ConstantDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/ConvolveDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/ConvolveDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/CropDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/CropDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/DCTDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/DCTDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/DFTDataNature.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/DFTDataNature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/DFTDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/DFTDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/DFTScalingType.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/DFTScalingType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/DilateDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/DilateDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/DivideByConstDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/DivideByConstDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/DivideComplexDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/DivideComplexDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/DivideDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/DivideDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/DivideIntoConstDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/DivideIntoConstDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/EncodeDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/EncodeDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/ErodeDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/ErodeDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/ErrorDiffusionDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/ErrorDiffusionDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/ExpDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/ExpDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/ExtremaDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/ExtremaDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/FPXDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/FPXDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/FileLoadDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/FileLoadDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/FileStoreDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/FileStoreDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/FilteredSubsampleDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/FilteredSubsampleDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/FormatDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/FormatDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/GIFDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/GIFDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/GradientMagnitudeDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/GradientMagnitudeDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/HistogramDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/HistogramDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/IDCTDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/IDCTDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/IDFTDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/IDFTDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/IIPDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/IIPDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/IIPResolutionDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/IIPResolutionDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/ImageFunctionDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/ImageFunctionDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/InvertDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/InvertDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/JPEGDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/JPEGDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/JaiI18N.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/JaiI18N.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/LogDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/LogDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/LookupDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/LookupDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/MagnitudeDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/MagnitudeDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/MagnitudeSquaredDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/MagnitudeSquaredDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/MatchCDFDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/MatchCDFDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/MaxDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/MaxDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/MaxFilterDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/MaxFilterDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/MaxFilterShape.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/MaxFilterShape.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/MeanDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/MeanDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/MedianFilterDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/MedianFilterDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/MedianFilterShape.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/MedianFilterShape.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/MinDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/MinDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/MinFilterDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/MinFilterDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/MinFilterShape.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/MinFilterShape.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/MosaicDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/MosaicDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/MosaicType.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/MosaicType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/MultiplyComplexDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/MultiplyComplexDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/MultiplyConstDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/MultiplyConstDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/MultiplyDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/MultiplyDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/NotDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/NotDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/NullDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/NullDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/OrConstDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/OrConstDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/OrDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/OrDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/OrderedDitherDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/OrderedDitherDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/OverlayDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/OverlayDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/PNGDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/PNGDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/PNMDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/PNMDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/PatternDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/PatternDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/PeriodicShiftDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/PeriodicShiftDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/PhaseDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/PhaseDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/PiecewiseDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/PiecewiseDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/PolarToComplexDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/PolarToComplexDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/RenderableDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/RenderableDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/RescaleDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/RescaleDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/RotateDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/RotateDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/ScaleDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/ScaleDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/ShearDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/ShearDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/ShearDir.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/ShearDir.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/StreamDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/StreamDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/SubsampleAverageDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/SubsampleAverageDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/SubsampleBinaryToGrayDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/SubsampleBinaryToGrayDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/SubtractConstDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/SubtractConstDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/SubtractDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/SubtractDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/SubtractFromConstDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/SubtractFromConstDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/TIFFDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/TIFFDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/ThresholdDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/ThresholdDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/TranslateDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/TranslateDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/TransposeDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/TransposeDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/TransposeType.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/TransposeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/URLDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/URLDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/UnsharpMaskDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/UnsharpMaskDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/WarpDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/WarpDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/XorConstDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/XorConstDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/operator/XorDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/operator/XorDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/registry/CIFRegistry.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/registry/CIFRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/registry/CRIFRegistry.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/registry/CRIFRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/registry/CollectionRegistryMode.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/registry/CollectionRegistryMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/registry/JaiI18N.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/registry/JaiI18N.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/registry/RCIFRegistry.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/registry/RCIFRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/registry/RIFRegistry.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/registry/RIFRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/registry/RemoteCRIFRegistry.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/registry/RemoteCRIFRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/registry/RemoteRIFRegistry.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/registry/RemoteRIFRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/registry/RemoteRenderableRegistryMode.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/registry/RemoteRenderableRegistryMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/registry/RemoteRenderedRegistryMode.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/registry/RemoteRenderedRegistryMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/registry/RenderableCollectionRegistryMode.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/registry/RenderableCollectionRegistryMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/registry/RenderableRegistryMode.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/registry/RenderableRegistryMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/registry/RenderedRegistryMode.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/registry/RenderedRegistryMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/registry/TileDecoderRegistry.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/registry/TileDecoderRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/registry/TileDecoderRegistryMode.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/registry/TileDecoderRegistryMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/registry/TileEncoderRegistry.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/registry/TileEncoderRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/registry/TileEncoderRegistryMode.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/registry/TileEncoderRegistryMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/remote/JAIRMIDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/remote/JAIRMIDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/remote/JaiI18N.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/remote/JaiI18N.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/remote/Negotiable.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/remote/Negotiable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/remote/NegotiableCapability.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/remote/NegotiableCapability.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/remote/NegotiableCapabilitySet.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/remote/NegotiableCapabilitySet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/remote/NegotiableCollection.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/remote/NegotiableCollection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/remote/NegotiableNumeric.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/remote/NegotiableNumeric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/remote/NegotiableNumericRange.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/remote/NegotiableNumericRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/remote/PlanarImageServerProxy.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/remote/PlanarImageServerProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/remote/RemoteCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/remote/RemoteCRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/remote/RemoteDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/remote/RemoteDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/remote/RemoteDescriptorImpl.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/remote/RemoteDescriptorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/remote/RemoteImagingException.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/remote/RemoteImagingException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/remote/RemoteJAI.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/remote/RemoteJAI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/remote/RemoteRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/remote/RemoteRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/remote/RemoteRenderableOp.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/remote/RemoteRenderableOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/remote/RemoteRenderedImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/remote/RemoteRenderedImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/remote/RemoteRenderedOp.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/remote/RemoteRenderedOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/remote/SerializableRenderedImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/remote/SerializableRenderedImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/remote/SerializableState.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/remote/SerializableState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/remote/Serializer.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/remote/Serializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/remote/SerializerFactory.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/remote/SerializerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/tilecodec/GZIPTileCodecDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/tilecodec/GZIPTileCodecDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/tilecodec/JPEGTileCodecDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/tilecodec/JPEGTileCodecDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/tilecodec/JaiI18N.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/tilecodec/JaiI18N.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/tilecodec/RawTileCodecDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/tilecodec/RawTileCodecDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/tilecodec/TileCodecDescriptor.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/tilecodec/TileCodecDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/tilecodec/TileCodecDescriptorImpl.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/tilecodec/TileCodecDescriptorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/tilecodec/TileCodecParameterList.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/tilecodec/TileCodecParameterList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/tilecodec/TileDecoder.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/tilecodec/TileDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/tilecodec/TileDecoderFactory.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/tilecodec/TileDecoderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/tilecodec/TileDecoderImpl.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/tilecodec/TileDecoderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/tilecodec/TileEncoder.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/tilecodec/TileEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/tilecodec/TileEncoderFactory.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/tilecodec/TileEncoderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/tilecodec/TileEncoderImpl.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/tilecodec/TileEncoderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/util/CaselessStringKey.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/util/CaselessStringKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/util/ImagingException.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/util/ImagingException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/util/ImagingListener.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/util/ImagingListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/util/JaiI18N.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/util/JaiI18N.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/util/Range.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/util/Range.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/widget/ImageCanvas.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/widget/ImageCanvas.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/widget/JaiI18N.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/widget/JaiI18N.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/widget/ScrollingImagePanel.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/widget/ScrollingImagePanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/eclipse/imagen/widget/ViewportListener.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/widget/ViewportListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/resources/META-INF/org.eclipse.imagen.registryFile.jai
+++ b/modules/core/src/main/resources/META-INF/org.eclipse.imagen.registryFile.jai
@@ -1,7 +1,7 @@
 #
 # $RCSfile: registryFile.jai,v $
 #
-# Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/core/src/main/resources/org/eclipse/imagen/org.eclipse.imagen.iterator.properties
+++ b/modules/core/src/main/resources/org/eclipse/imagen/org.eclipse.imagen.iterator.properties
@@ -1,7 +1,7 @@
 #
 # $RCSfile: org.eclipse.imagen.iterator.properties,v $
 #
-# Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/core/src/main/resources/org/eclipse/imagen/org.eclipse.imagen.media.codec.properties
+++ b/modules/core/src/main/resources/org/eclipse/imagen/org.eclipse.imagen.media.codec.properties
@@ -1,7 +1,7 @@
 #
 # $RCSfile: org.eclipse.imagen.media.codec.properties,v $
 #
-# Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/core/src/main/resources/org/eclipse/imagen/org.eclipse.imagen.media.codecimpl.fpx.properties
+++ b/modules/core/src/main/resources/org/eclipse/imagen/org.eclipse.imagen.media.codecimpl.fpx.properties
@@ -1,7 +1,7 @@
 #
 # $RCSfile: org.eclipse.imagen.media.codecimpl.fpx.properties,v $
 #
-# Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/core/src/main/resources/org/eclipse/imagen/org.eclipse.imagen.media.codecimpl.properties
+++ b/modules/core/src/main/resources/org/eclipse/imagen/org.eclipse.imagen.media.codecimpl.properties
@@ -1,7 +1,7 @@
 #
 # $RCSfile: org.eclipse.imagen.media.codecimpl.properties,v $
 #
-# Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/core/src/main/resources/org/eclipse/imagen/org.eclipse.imagen.media.codecimpl.util.properties
+++ b/modules/core/src/main/resources/org/eclipse/imagen/org.eclipse.imagen.media.codecimpl.util.properties
@@ -1,7 +1,7 @@
 #
 # $RCSfile: org.eclipse.imagen.properties,v $
 #
-# Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -317,7 +317,7 @@ WritableRenderedImageAdapter1=The Raster parameter supplied is null.
 #
 # $RCSfile: org.eclipse.imagen.media.util.properties,v $
 #
-# Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/core/src/main/resources/org/eclipse/imagen/org.eclipse.imagen.media.iterator.properties
+++ b/modules/core/src/main/resources/org/eclipse/imagen/org.eclipse.imagen.media.iterator.properties
@@ -1,7 +1,7 @@
 #
 # $RCSfile: org.eclipse.imagen.media.iterator.properties,v $
 #
-# Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/core/src/main/resources/org/eclipse/imagen/org.eclipse.imagen.media.mlib.properties
+++ b/modules/core/src/main/resources/org/eclipse/imagen/org.eclipse.imagen.media.mlib.properties
@@ -1,7 +1,7 @@
 #
 # $RCSfile: org.eclipse.imagen.media.mlib.properties,v $
 #
-# Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/core/src/main/resources/org/eclipse/imagen/org.eclipse.imagen.media.opimage.properties
+++ b/modules/core/src/main/resources/org/eclipse/imagen/org.eclipse.imagen.media.opimage.properties
@@ -1,7 +1,7 @@
 #
 # $RCSfile: org.eclipse.imagen.media.opimage.properties,v $
 #
-# Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/core/src/main/resources/org/eclipse/imagen/org.eclipse.imagen.media.rmi.properties
+++ b/modules/core/src/main/resources/org/eclipse/imagen/org.eclipse.imagen.media.rmi.properties
@@ -1,7 +1,7 @@
 #
 # $RCSfile: org.eclipse.imagen.media.rmi.properties,v $
 #
-# Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/core/src/main/resources/org/eclipse/imagen/org.eclipse.imagen.media.tilecodec.properties
+++ b/modules/core/src/main/resources/org/eclipse/imagen/org.eclipse.imagen.media.tilecodec.properties
@@ -1,7 +1,7 @@
 #
 # $RCSfile: org.eclipse.imagen.media.tilecodec.properties,v $
 #
-# Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/core/src/main/resources/org/eclipse/imagen/org.eclipse.imagen.media.util.properties
+++ b/modules/core/src/main/resources/org/eclipse/imagen/org.eclipse.imagen.media.util.properties
@@ -1,7 +1,7 @@
 #
 # $RCSfile: org.eclipse.imagen.media.util.properties,v $
 #
-# Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/core/src/main/resources/org/eclipse/imagen/org.eclipse.imagen.operator.properties
+++ b/modules/core/src/main/resources/org/eclipse/imagen/org.eclipse.imagen.operator.properties
@@ -1,7 +1,7 @@
 #
 # $RCSfile: org.eclipse.imagen.operator.properties,v $
 #
-# Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/core/src/main/resources/org/eclipse/imagen/org.eclipse.imagen.properties
+++ b/modules/core/src/main/resources/org/eclipse/imagen/org.eclipse.imagen.properties
@@ -1,7 +1,7 @@
 #
 # $RCSfile: org.eclipse.imagen.properties,v $
 #
-# Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/core/src/main/resources/org/eclipse/imagen/org.eclipse.imagen.registry.properties
+++ b/modules/core/src/main/resources/org/eclipse/imagen/org.eclipse.imagen.registry.properties
@@ -1,7 +1,7 @@
 #
 # $RCSfile: org.eclipse.imagen.registry.properties,v $
 #
-# Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/core/src/main/resources/org/eclipse/imagen/org.eclipse.imagen.remote.properties
+++ b/modules/core/src/main/resources/org/eclipse/imagen/org.eclipse.imagen.remote.properties
@@ -1,7 +1,7 @@
 #
 # $RCSfile: org.eclipse.imagen.remote.properties,v $
 #
-# Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/core/src/main/resources/org/eclipse/imagen/org.eclipse.imagen.tilecodec.properties
+++ b/modules/core/src/main/resources/org/eclipse/imagen/org.eclipse.imagen.tilecodec.properties
@@ -1,7 +1,7 @@
 #
 # $RCSfile: org.eclipse.imagen.tilecodec.properties,v $
 #
-# Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/core/src/main/resources/org/eclipse/imagen/org.eclipse.imagen.util.properties
+++ b/modules/core/src/main/resources/org/eclipse/imagen/org.eclipse.imagen.util.properties
@@ -1,7 +1,7 @@
 #
 # $RCSfile: org.eclipse.imagen.util.properties,v $
 #
-# Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/core/src/main/resources/org/eclipse/imagen/org.eclipse.imagen.widget.properties
+++ b/modules/core/src/main/resources/org/eclipse/imagen/org.eclipse.imagen.widget.properties
@@ -1,7 +1,7 @@
 #
 # $RCSfile: org.eclipse.imagen.widget.properties,v $
 #
-# Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/FCTmediaLib.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/FCTmediaLib.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/FFTmediaLib.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/FFTmediaLib.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/JaiI18N.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/JaiI18N.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MediaLibAccessor.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MediaLibAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibAbsoluteOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibAbsoluteOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibAbsoluteRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibAbsoluteRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibAddConstOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibAddConstOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibAddConstRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibAddConstRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibAddOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibAddOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibAddRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibAddRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibAffineBicubicOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibAffineBicubicOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibAffineBilinearOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibAffineBilinearOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibAffineNearestOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibAffineNearestOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibAffineOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibAffineOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibAffineRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibAffineRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibAffineTableOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibAffineTableOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibAndConstOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibAndConstOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibAndConstRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibAndConstRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibAndOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibAndOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibAndRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibAndRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibBandCombineOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibBandCombineOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibBandCombineRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibBandCombineRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibBandSelectOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibBandSelectOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibBandSelectRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibBandSelectRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibBinarizeOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibBinarizeOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibBinarizeRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibBinarizeRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibBoxFilterRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibBoxFilterRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibClampOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibClampOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibClampRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibClampRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibCompositeOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibCompositeOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibCompositeRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibCompositeRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibConvolveNxNOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibConvolveNxNOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibConvolveOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibConvolveOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibConvolveRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibConvolveRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibCopyOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibCopyOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibDCTRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibDCTRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibDFTOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibDFTOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibDFTRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibDFTRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibDilate3PlusOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibDilate3PlusOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibDilate3SquareOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibDilate3SquareOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibDilateRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibDilateRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibDivideByConstRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibDivideByConstRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibDivideIntoConstOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibDivideIntoConstOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibDivideIntoConstRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibDivideIntoConstRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibDivideOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibDivideOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibDivideRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibDivideRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibErode3PlusOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibErode3PlusOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibErode3SquareOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibErode3SquareOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibErodeRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibErodeRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibErrorDiffusionOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibErrorDiffusionOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibErrorDiffusionRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibErrorDiffusionRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibExpOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibExpOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibExpRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibExpRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibExtremaOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibExtremaOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibExtremaRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibExtremaRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibFilteredSubsampleOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibFilteredSubsampleOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibFilteredSubsampleRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibFilteredSubsampleRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibGradientOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibGradientOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibGradientRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibGradientRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibHistogramOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibHistogramOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibHistogramRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibHistogramRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibIDCTRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibIDCTRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibIDFTRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibIDFTRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibInvertOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibInvertOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibInvertRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibInvertRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibLogOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibLogOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibLogRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibLogRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibLookupOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibLookupOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibLookupRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibLookupRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibMaxFilterOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibMaxFilterOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibMaxFilterRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibMaxFilterRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibMaxOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibMaxOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibMaxRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibMaxRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibMeanOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibMeanOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibMeanRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibMeanRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibMedianFilterOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibMedianFilterOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibMedianFilterRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibMedianFilterRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibMinFilterOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibMinFilterOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibMinFilterRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibMinFilterRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibMinOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibMinOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibMinRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibMinRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibMosaicOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibMosaicOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibMosaicRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibMosaicRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibMultiplyConstOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibMultiplyConstOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibMultiplyConstRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibMultiplyConstRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibMultiplyOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibMultiplyOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibMultiplyRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibMultiplyRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibNotOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibNotOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibNotRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibNotRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibOrConstOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibOrConstOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibOrConstRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibOrConstRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibOrOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibOrOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibOrRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibOrRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibOrderedDitherOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibOrderedDitherOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibOrderedDitherRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibOrderedDitherRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibRescaleOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibRescaleOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibRescaleRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibRescaleRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibRotateRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibRotateRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibScaleBicubicOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibScaleBicubicOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibScaleBilinearOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibScaleBilinearOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibScaleNearestOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibScaleNearestOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibScaleOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibScaleOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibScaleRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibScaleRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibScaleTableOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibScaleTableOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibSeparableConvolveOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibSeparableConvolveOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibShearRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibShearRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibSobelOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibSobelOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibSubsampleAverageOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibSubsampleAverageOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibSubsampleAverageRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibSubsampleAverageRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibSubsampleBinaryToGrayOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibSubsampleBinaryToGrayOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibSubsampleBinaryToGrayRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibSubsampleBinaryToGrayRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibSubtractConstRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibSubtractConstRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibSubtractFromConstOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibSubtractFromConstOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibSubtractFromConstRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibSubtractFromConstRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibSubtractOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibSubtractOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibSubtractRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibSubtractRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibThresholdOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibThresholdOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibThresholdRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibThresholdRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibTranslateRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibTranslateRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibTransposeOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibTransposeOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibTransposeRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibTransposeRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibUnsharpMaskRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibUnsharpMaskRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibUtils.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibWarpGridOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibWarpGridOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibWarpGridTableOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibWarpGridTableOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibWarpPolynomialOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibWarpPolynomialOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibWarpPolynomialTableOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibWarpPolynomialTableOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibWarpRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibWarpRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibXorConstOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibXorConstOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibXorConstRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibXorConstRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibXorOpImage.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibXorOpImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibXorRIF.java
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/MlibXorRIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/org.eclipse.imagen.media.mlib.properties
+++ b/modules/mlib/src/main/java/org/eclipse/imagen/media/mlib/org.eclipse.imagen.media.mlib.properties
@@ -1,7 +1,7 @@
 #
 # $RCSfile: org.eclipse.imagen.media.mlib.properties,v $
 #
-# Copyright (c) [2019,] 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This change fixes the header information to the intended:

>   Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.

As per email discussion.