### PR TITLE
Do not dispose Graphics2D field in finalizer

### DIFF
--- a/modules/core/src/main/java/org/eclipse/imagen/GraphicsJAI.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/GraphicsJAI.java
@@ -429,6 +429,18 @@ public class GraphicsJAI extends Graphics2D {
     }
 
     /**
+     * Graphics has a finalize method that automatically calls dispose()
+     * for subclasses.  We override it here with an empty method so that
+     * it doesn't dispose the private Graphics2D field.
+     *
+     * @see <a href="https://web.archive.org/web/20110412105630/
+     * http://java.net/jira/browse/JAI_CORE-96">JIRA JAI-CORE 96</a>
+     */
+    public void finalize() {
+        // DO NOT REMOVE THIS METHOD
+    }
+
+    /**
      * See comments in java.awt.Graphics2D.
      *
      * @see java.awt.Graphics2D#draw(Shape)


### PR DESCRIPTION
There is an error in GraphicsJAI when one attempts to create a GraphicsJAI froman existing Graphics2D. If the GraphicsJAI goes out of scope it can ruin theoriginal Graphics2D and causes some method invokations, such as to g2d.fill(shape), to be ignored.

This bug was reported as [JAI_CORE-96](https://web.archive.org/web/20110412105630/http://java.net/jira/browse/JAI_CORE-96).